### PR TITLE
Adding toml++

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ C++ Benchmark Authoring Library/Framework.
 
 * [json](https://github.com/nlohmann/json) - JSON for Modern C++.
 * [jsoncpp](https://github.com/open-source-parsers/jsoncpp) - A C++ library for interacting with JSON.
+* [toml++](https://github.com/marzer/tomlplusplus) - A header-only C++17 library for parsing TOML v0.5.0 and later.
 * [tinytoml](https://github.com/mayah/tinytoml) -A header only C++11 library for parsing TOML.
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) - A YAML parser and emitter in C++.
 * [cpptoml](https://github.com/skystrife/cpptoml) - A header-only library for parsing TOML configuration files.


### PR DESCRIPTION
`toml++` is a C++17 header-only library for parsing TOML. MIT license.

Repository: https://github.com/marzer/tomlplusplus

Homepage (doubles as API documentation): https://marzer.github.io/tomlplusplus/