### PR TITLE
Add section on starter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Start with [SG20 Education and Recommended Videos for Teaching C++](https://www.
 * [The C++ Programming Language](https://isocpp.org/) - News, Status & Discussion about Standard C++.
 * [C++ Standards Committee Papers](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/) - The proposed changes to the C++ standard.
 
-## Starter templates
+## Project Starter Templates
 
-* [TheLartians/ModernCppStarter](https://github.com/TheLartians/ModernCppStarter) - A template for kick-starting modern C++ projects using CMake, CI, code coverage, clang-format, reproducible dependency management and more.
+* [ModernCppStarter](https://github.com/TheLartians/ModernCppStarter) - A template for kick-starting modern C++ projects using CMake, CI, code coverage, clang-format, reproducible dependency management and more.
+* [Pitchfork](https://github.com/vector-of-bool/pitchfork) - Pitchfork is a Set of C++ Project Conventions.  
 
 ## Libraries
 
@@ -245,7 +246,6 @@ C++ Benchmark Authoring Library/Framework.
 * [indicators](https://github.com/p-ranav/indicators) - Activity Indicators for Modern C++.
 * [AssociatedEnum](https://github.com/Alkenso/asenum) - header-only library for C++ for enumerations with associated values.
 * [openFrameworks](https://openframeworks.cc/) - an open source C++ toolkit for creative coding.
-* [Pitchfork](https://github.com/vector-of-bool/pitchfork) - Pitchfork is a Set of C++ Project Conventions.  
 * [tabulate](https://github.com/p-ranav/tabulate) - Table Maker for Modern C++.
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Start with [SG20 Education and Recommended Videos for Teaching C++](https://www.
 * [The C++ Programming Language](https://isocpp.org/) - News, Status & Discussion about Standard C++.
 * [C++ Standards Committee Papers](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/) - The proposed changes to the C++ standard.
 
+## Starter templates
+
+* [TheLartians/ModernCppStarter](https://github.com/TheLartians/ModernCppStarter) - A template for kick-starting modern C++ projects using CMake, CI, code coverage, clang-format, reproducible dependency management and more.
+
 ## Libraries
 
 This is not supposed to be a comprehensive list of all C and C++


### PR DESCRIPTION
Hey, thanks again for compiling this great list on modern C++ projects! 
As someone who always starts new projects by reusing the structure from previous ones I feel that a category for modern starter templates would be a great addition. As I'm currently unaware of any others I've added [my own](https://github.com/TheLartians/ModernCppStarter) to start. I think this goes especially well with the Best Practices section above as the starter enforces most of these guidelines by design.