### PR TITLE
Added more project templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Start with [SG20 Education and Recommended Videos for Teaching C++](https://www.
 ## Project Starter Templates
 
 * [ModernCppStarter](https://github.com/TheLartians/ModernCppStarter) - A template for kick-starting modern C++ projects using CMake, CI, code coverage, clang-format, reproducible dependency management and more.
+* [modern-cpp-template](https://github.com/filipdutescu/modern-cpp-template) - A template for modern C++ projects using CMake, Clang-Format, CI, unit testing and more, with support for downstream inclusion.
+* [cpp_starter_project](https://github.com/lefticus/cpp_starter_project/) - A template CMake project to get you started with C++ and tooling.
 * [Pitchfork](https://github.com/vector-of-bool/pitchfork) - Pitchfork is a Set of C++ Project Conventions.  
 
 ## Libraries


### PR DESCRIPTION
## Proposed changes
  * Added [my own modern C++ template](https://github.com/filipdutescu/modern-cpp-template)
  * Added [Jason Turner](https://github.com/lefticus/)'s ([@lefticus](https://github.com/lefticus/)) [C++ starter project](https://github.com/lefticus/cpp_starter_project)

## Motivation behind changes
There was only one templated presented before, leaving developers without choice, unless they actively searched for others. I wish to add my own template, as well as Jason Turner's starter project, as alternatives to @TheLartians's template. In my opinion, each has its own teachings to offer developers and while similar in scope, the different implementations from each show different approaches to setting up C++ projects.

### Pull Request Readiness Checklist
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work