### PR TITLE
Remove C++ Best Practices gitbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Start with [SG20 Education and Recommended Videos for Teaching C++](https://blog
 
 ### Websites
 
-* [C++ Best Practices](https://lefticus.gitbooks.io/cpp-best-practices/content/) - Collaborative Collection of C++ Best Practices.
 * [C++ Patterns](https://cpppatterns.com/) - A repository of modern C++ patterns.
 * [C++ reference](https://en.cppreference.com/w/)🔥 - C++ reference.
 * [C++ By Example](http://cbyexample.com) - Learn C++ by Example!


### PR DESCRIPTION
The book's content was transferred to https://leanpub.com/cppbestpractices.

Closes https://github.com/rigtorp/awesome-modern-cpp/issues/129.