### PR TITLE
Add Doxide under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ C++ Benchmark Authoring Library/Framework.
 * [Compiler Explorer](https://gcc.godbolt.org/) - Interactively explore the assembly output of your C++ code.
 * [cquery](https://github.com/cquery-project/cquery) - C/C++ language server supporting multi-million line code base, powered by libclang. Emacs, Vim, VSCode, and others with language server protocol support. Cross references, completion, diagnostics, semantic highlighting and more (No more commits since Nov 27, 2018)
 * [ccls](https://github.com/MaskRay/ccls) - C/C++/ObjC language server supporting cross references, hierarchies, completion and semantic highlighting, forked from cquery, which is under active development
+* [Doxide](https://github.com/lawmurray/doxide) - Modern documentation for modern C++, configure with YAML, output Markdown.
 * [irony-mode](https://github.com/Sarcasm/irony-mode) -  A C/C++ minor mode for Emacs powered by libclang.
 * [modern-cpp-font-lock-mode](https://github.com/ludwigpacifici/modern-cpp-font-lock) - Syntax highlighting support for Modern C++ with emacs
  


### PR DESCRIPTION
This pull request adds [Doxide](https://github.com/lawmurray/doxide) under Tools > Misc (there is no Documentation category, would that be worth adding?). Doxide is a new tool aimed at modern C++, and modern documentation for it.

* [Doxide](https://github.com/lawmurray/doxide) - Modern documentation for modern C++, configure with YAML, output Markdown.
