### PR TITLE
Mention the Reddit API blackout protest

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Read the latest C++ standard proposals:
 * [C++ Standards Committee Papers](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/).
 
 Discuss everything related to C++:
-* [r/cpp](https://www.reddit.com/r/cpp/) - The C++ subreddit.
+* [r/cpp](https://www.reddit.com/r/cpp/) - The C++ subreddit. (Private indefinitely because of the Reddit blackout protest.)
 * [C++ Slack](https://cppalliance.org/slack/) - The C++ Slack workspace.
 * [CoreHard Telegram group](https://t.me/corehard_by).
 
 Ask your C++ questions:
-* [r/cpp_questions](https://www.reddit.com/r/cpp_questions) - A subreddit for C++ questions and answers.
+* [r/cpp_questions](https://www.reddit.com/r/cpp_questions) - A subreddit for C++ questions and answers. (Private indefinitely because of the Reddit blackout protest.)
 * [Stackoverflow C++](https://stackoverflow.com/questions/tagged/c%2b%2b) / [C++11](https://stackoverflow.com/questions/tagged/c%2b%2b11) / [C++14](https://stackoverflow.com/questions/tagged/c%2b%2b14) / [C++17](https://stackoverflow.com/questions/tagged/c%2b%2b17) / [C++20](https://stackoverflow.com/questions/tagged/c%2b%2b20) - Stackoverflow questions about C++.
 
 Maybe your question was already answered in a FAQ?:


### PR DESCRIPTION
There are two links to `r/cpp` and `r/cpp_questions`. Both of these subreddits are taking part in the [Reddit API blackout protest](https://www.theverge.com/2023/6/5/23749188/reddit-subreddit-private-protest-api-changes-apollo-charges) indefinitely until API changes are reversed. The Reddit CEO has said [he will not rollback changes to the API](https://techcrunch.com/2023/06/16/reddit-ceo-lashes-out-on-protests-moderators-and-third-party-apps/?guccounter=1&guce_referrer=aHR0cHM6Ly9kdWNrZHVja2dvLmNvbS8&guce_referrer_sig=AQAAAAJ8-Wsy4MHcjRtgkBAh6OgutKYEbeZpJg1aBsFze-E-jWOmH3zQ2ABA0OdwtUTsuc-UvVyJQdze6ajE00FkcO0i47bapjPY5_TOYIwsjPXrnrmeqNxUKiTnuIy81bEBjR5P3UdPWPx1hj6v8AAVKwor75u5Osl8npqXYzy0bbdI). Therefore, it seems like these subreddits will be private for a while.

This PR adds a short disclaimer after both links to explain why they link to private communities as the explanation on the actual pages only appears for me on Firefox and not Safari.